### PR TITLE
Fix for role-based permissions in hassio

### DIFF
--- a/remote-backup/config.json
+++ b/remote-backup/config.json
@@ -7,6 +7,7 @@
   "startup": "once",
   "boot": "manual",
   "hassio_api": true,
+  "hassio_role": "backup",
   "map": ["backup:rw"],
   "image": "fixated/remote-backup-{arch}",
   "options": {


### PR DESCRIPTION
Use a specific role for backup add-ons (https://github.com/home-assistant/hassio/pull/755) in config.json.

Fixes https://github.com/mr-bjerre/hassio-remote-backup/issues/9 for real, since this is the repo users add,
and this config.json is used when installing add-ons (AFAIK).

Edit: also opened https://github.com/mr-bjerre/hassio-remote-backup/pull/11 since the config.json should be the same (with the exeption of the `image`-option).